### PR TITLE
Update gem versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
-    ast (2.0.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
     astrolabe (1.3.1)
       parser (~> 2.2)
     axiom-types (0.1.1)
@@ -11,41 +12,41 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    declarative (0.0.20)
+    declarative-option (0.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.4.4)
     equalizer (0.0.11)
-    excon (0.45.4)
-    faraday (0.9.1)
+    excon (0.78.0)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    ice_nine (0.11.1)
-    mini_portile (0.6.2)
-    multi_json (1.11.2)
-    multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    oj (2.16.1)
-    parser (2.2.2.6)
-      ast (>= 1.1, < 3.0)
-    powerpack (0.1.1)
-    rainbow (2.0.0)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    ice_nine (0.11.2)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
+    powerpack (0.1.2)
+    public_suffix (4.0.6)
+    rainbow (2.2.2)
+      rake
     rake (10.4.2)
-    representable (2.2.3)
-      multi_json
-      nokogiri
-      uber (~> 0.0.7)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
       rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.0)
+    rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.0)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
@@ -55,18 +56,18 @@ GEM
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.5)
-    thread_safe (0.3.5)
-    tracker_api (0.2.10)
+    ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tracker_api (0.2.12)
       addressable
       equalizer
       excon
       faraday (~> 0.9.0)
       faraday_middleware
-      oj
+      multi_json
       representable
       virtus
-    uber (0.0.13)
+    uber (0.1.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -83,4 +84,4 @@ DEPENDENCIES
   tracker_api (~> 0.2.10)
 
 BUNDLED WITH
-   1.10.5
+   1.17.3


### PR DESCRIPTION
- Older gems with native dependencies weren't installing cleanly on 2020-era OSX and Ruby

Authored-by: Greg Cobb <gcobb@pivotal.io>